### PR TITLE
Allow auth on non-public surveys

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,6 +18,15 @@
             "name": "Lockout time (minutes; default = 5 minutes)",
             "type": "text",
             "repeatable": false
+        },
+        {
+            "key": "surveyauth_allow_nonpublic",
+            "name": "Allow module to authenticate on non-public surveys",
+            "type": "checkbox",
+            "choices": [
+                { "value": "1", "name": "Allow" }
+            ],
+            "repeatable": false
         }
     ],
     "project-settings": [


### PR DESCRIPTION
Adds system-level setting to enable the EM to apply to both public and non-public surveys.

See issue #6 