### PR TITLE
Implement new LDAP feature: Retrieve user data from user_info after attribute mapping.

### DIFF
--- a/SurveyAuthExternalModule.php
+++ b/SurveyAuthExternalModule.php
@@ -631,6 +631,24 @@ class SurveyAuthExternalModule extends AbstractExternalModule {
                 }
             }
             @ldap_unbind($ldap);
+
+            // Retrieve data from redcap_user_information instead of mapping attributes
+            // https://github.com/grezniczek/redcap_survey_auth/issues/12
+            if ($this->settings->ldapNoMapping) {
+
+                $sql = 'SELECT user_email,user_firstname,user_lastname FROM redcap_user_information WHERE username = ?';
+                $user_info_result = $this->query($sql, [$result["username"]]);
+        
+                while($row = $user_info_result->fetch_array()){
+                    $user_info = $row;
+                }
+
+                $fullname = $user_info["user_firstname"] . " " . $user_info["user_lastname"];
+                $email = $user_info["user_email"];
+                if (strlen($fullname)) $result["fullname"] = $fullname;
+                if (strlen($email)) $result["email"] = strtolower($email);
+            }
+
         }
         catch (\Exception $e) {
             $result["log_error"][] = "LDAP error: " . $e->getMessage();

--- a/classes/SurveyAuthSettings.php
+++ b/classes/SurveyAuthSettings.php
@@ -26,6 +26,7 @@ class SurveyAuthSettings {
     public $useCustom;
     public $customCredentials;
     public $otherLDAPConfigs;
+    public $ldapNoMapping;
     public $ldapMappings = array(
         "email" => array(),
         "fullname" => array(),
@@ -73,6 +74,7 @@ class SurveyAuthSettings {
             $this->useOtherLDAP = $this->getValue("surveyauth_useotherldap", false);
             $this->useCustom = $this->getValue("surveyauth_usecustom", false);
             $this->otherLDAPConfigs = json_decode($this->getValue("surveyauth_otherldap", "[]"), true);
+            $this->ldapNoMapping = $this->getValue("surveyauth_ldap_nomap", false);
             if (!is_array($this->otherLDAPConfigs)) $this->otherLDAPConfigs = array();
             $defaults = array(
                 "email" => "email,mail",

--- a/config.json
+++ b/config.json
@@ -139,6 +139,18 @@
             "required": true
         },
         {
+            "key":"surveyauth_ldap_nomap",
+            "name":"Retrieve additional user data stored by REDCap when not obtainable from LDAP attributes",
+            "type": "checkbox",
+            "branchingLogic": {
+                "type": "or",
+                "conditions": [
+                    { "field": "surveyauth_useldap", "value": true },
+                    { "field": "surveyauth_useotherldap", "value": true }
+                ]
+            }            
+        },
+        {
             "key": "surveyauth_ldapmap_email",
             "name": "LDAP: Attribute mapping for email (separate multiple names by commas; default: 'email,mail')",
             "type": "text",


### PR DESCRIPTION
This PR implements a feature that allows to retrieve additional user data from redcap_user_information table, when the data is not obtainable through LDAP attribute mapping.

Initial Issue: https://github.com/grezniczek/redcap_survey_auth/issues/12

Implementation notes:
1) I have tried to touch as less code as possible, hence I did not chose a condition that skips LDAP attribute mapping. It could be possible though to add an additional check, that ensure we only retrieve data from the table when mapped attribute results are empty.

2) Please feel free to adjust any names of methods / variables or descriptions.

3) I was not able to add an advanced branching logic to the checkbox within `config.js`. It would be of course best, when checkbox `surveyauth_ldap_nomap` is `True`, that all mapping fields are hidden. But I guess this is currently no possible.